### PR TITLE
Change ctaButton one to directly use it's url

### DIFF
--- a/layouts/partials/landing/hero.html
+++ b/layouts/partials/landing/hero.html
@@ -62,7 +62,7 @@
 
                     <div class="mt-3">
                         {{ with .ctaButton }}
-                            <a href="{{ relLangURL .Site.Data.landing.hero.ctaButton.url }}" class="btn btn-lg btn-primary me-2 mt-2">
+                            <a href="{{ relLangURL .url }}" class="btn btn-lg btn-primary me-2 mt-2">
                                 {{ with .icon }}
                                     <span class="material-icons align-middle">{{ . }}</span>
                                 {{ end }}


### PR DESCRIPTION
### Changes

Fix bad link for context action button 1 (ctaButton) in the hero section of the landing page.

<!-- ### Tests
- [ ] Automated tests have been added
- [x] This PR does not require tests -->

<!-- ### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change -->

<!-- ### Documentation
- [x] This change does not need a documentation update -->

### Dark mode
- [ ] The UI has been tested both in dark and light mode
- [x] This PR does not change the UI
