### PR TITLE
adjusted toc-mobile design

### DIFF
--- a/assets/docs/js/toc-mobile-scrollspy.js
+++ b/assets/docs/js/toc-mobile-scrollspy.js
@@ -1,18 +1,18 @@
-// ToC Mobile Menu (Bootstrap 5 Dropdown with ScrollSpy)
-const scrollArea = document.getElementById('content');
-const tocBtn = document.getElementById('toc-dropdown-btn');
-scrollArea.addEventListener("activate.bs.scrollspy", function(){
-    var currentItem = document.querySelector('.dropdown-menu li > a.active').innerHTML;
-    tocBtn.innerHTML = currentItem;
-})
+// // ToC Mobile Menu (Bootstrap 5 Dropdown with ScrollSpy)
+// const scrollArea = document.getElementById('content');
+// const tocBtn = document.getElementById('toc-dropdown-btn');
+// scrollArea.addEventListener("activate.bs.scrollspy", function(){
+//     var currentItem = document.querySelector('.dropdown-menu li > a.active').innerHTML;
+//     tocBtn.innerHTML = currentItem;
+// })
 
-tocBtn.addEventListener('shown.bs.dropdown', event => {
-    tocBtn.style.borderBottom = 'none'
-    tocBtn.style.borderRadius = '4px 4px 0 0'
-    // console.log("dropdown opened");
-})
-tocBtn.addEventListener('hidden.bs.dropdown', event => {
-    tocBtn.style.borderBottom = '1px solid var(--alert-border-color)'
-    tocBtn.style.borderRadius = '4px'
-    // console.log("dropdown closed");
-});
+// tocBtn.addEventListener('shown.bs.dropdown', event => {
+//     tocBtn.style.borderBottom = 'none'
+//     tocBtn.style.borderRadius = '4px 4px 0 0'
+//     // console.log("dropdown opened");
+// })
+// tocBtn.addEventListener('hidden.bs.dropdown', event => {
+//     tocBtn.style.borderBottom = '1px solid var(--alert-border-color)'
+//     tocBtn.style.borderRadius = '4px'
+//     // console.log("dropdown closed");
+// });

--- a/assets/docs/scss/custom/structure/_toc.scss
+++ b/assets/docs/scss/custom/structure/_toc.scss
@@ -18,25 +18,14 @@
 
 .docs-toc-mobile {
     position: sticky;
-    // top: 71px; // important (must be set)
-    top: 85px; // important (must be set)
+    margin-bottom: 1rem;
     padding-left: calc(var(--bs-gutter-x) * 1.05);
     padding-right: calc(var(--bs-gutter-x) * 1.05);
     z-index: 20;
 
-    // &.toc-pinned {
-    //     padding: 0;
-
-    //     .dropdown-toggle {
-    //         border-left: 0;
-    //         border-right: 0;
-    //         border-top: 0;
-    //         border-radius: 0;
-    //     }
-    // }
-
     a {
         color: var(--text-default);
+        text-decoration: underline;
     }
     a:hover {
         color: var(--toc-mobile-link-hover-color);

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -117,9 +117,7 @@ If so, collect and consolidate the items config from each enabled instance
                                             {{ end }}
                                             {{ if site.Params.docs.tocMobile | default true }}
                                             <div class="docs-toc-mobile {{ if .IsNode }}visually-hidden{{ else }}{{end}} {{ if and (ne .Params.toc false) (ne .TableOfContents "<nav id=\"TableOfContents\"></nav>") }}{{ else }}visually-hidden{{ end }} {{ if site.Params.docs.tocMobile | default true }}{{ else }}visually-hidden{{ end }} d-print-none d-xl-none">
-                                                <button id="toc-dropdown-btn" class="btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-offset="0,0" aria-expanded="false">
-                                                    Table of Contents
-                                                </button>
+                                                <h1>Table of Contents</h1>
                                                 {{- partial (printf "%s/%s" ($.Scratch.Get "pathName") "toc-mobile.html") . -}}
                                             </div>
                                             {{ end -}}


### PR DESCRIPTION
This pull request focuses on deprecating and simplifying the implementation of the Table of Contents (ToC) mobile menu. The changes include commenting out JavaScript functionality, modifying SCSS styles, and replacing a dropdown button with a static heading in the HTML structure.

### Deprecation of ToC Mobile Menu Functionality:
* [`assets/docs/js/toc-mobile-scrollspy.js`](diffhunk://#diff-57fa670c8e4dc3b6fa8cd5f0b06bf233199918f5b5a5a6f55846a9d27d422131L1-R18): Commented out all JavaScript code related to the ToC mobile menu, including ScrollSpy activation and dropdown event listeners, effectively disabling this functionality.

### Styling Adjustments:
* [`assets/docs/scss/custom/structure/_toc.scss`](diffhunk://#diff-a3811e1efe90c40e27c3905283bcf01b532c3bbb0ba20d90bb00400835f11e5eL21-R28): Removed the `top` property for `.docs-toc-mobile`, added a `margin-bottom` for spacing, and updated anchor links within the ToC to include underlined text for better visibility.

### Structural Changes:
* [`layouts/_default/baseof.html`](diffhunk://#diff-ec6e7cb6e89cbe10d49085811bd67ad23df375247295fc387da90f5fdc56de7fL120-R120): Replaced the dropdown button for the ToC mobile menu with a static `<h1>` heading, simplifying the layout and removing interactive dropdown functionality.### Changes

